### PR TITLE
fix: resolve vulnerability with escape quote token

### DIFF
--- a/src/main/ts/util.ts
+++ b/src/main/ts/util.ts
@@ -68,6 +68,7 @@ export const quote = (arg: string): string => {
     arg
       .replace(/\\/g, '\\\\')
       .replace(/'/g, "\\'")
+      .replace(/"/g, "\\\"")
       .replace(/\f/g, '\\f')
       .replace(/\n/g, '\\n')
       .replace(/\r/g, '\\r')

--- a/src/main/ts/util.ts
+++ b/src/main/ts/util.ts
@@ -63,20 +63,18 @@ export const quote = (arg: string): string => {
   if (arg === '') return `$''`
   if (/^[\w./:=@-]+$/.test(arg)) return arg
 
-  return (
-    `$'` +
-    arg
-      .replace(/\\/g, '\\\\')
-      .replace(/'/g, "\\'")
-      .replace(/"/g, "\\\"")
-      .replace(/\f/g, '\\f')
-      .replace(/\n/g, '\\n')
-      .replace(/\r/g, '\\r')
-      .replace(/\t/g, '\\t')
-      .replace(/\v/g, '\\v')
-      .replace(/\0/g, '\\0') +
-    `'`
-  )
+  const safe = arg
+    .replace(/\\/g, `\\\\`)
+    .replace(/'/g, `\\'`)
+    .replace(/"/g, `\\"`)
+    .replace(/\f/g, `\\f`)
+    .replace(/\n/g, `\\n`)
+    .replace(/\r/g, `\\r`)
+    .replace(/\t/g, `\\t`)
+    .replace(/\v/g, `\\v`)
+    .replace(/\0/g, `\\0`)
+
+  return `$'${safe}'`
 }
 
 export function quotePwsh(arg: string): string {

--- a/src/test/ts/util.test.ts
+++ b/src/test/ts/util.test.ts
@@ -34,5 +34,6 @@ describe('util', () => {
   test('quote()', () => {
     assert.equal(quote(''), "$''")
     assert.equal(quote('foo bar\r\nbaz'), "$'foo bar\\r\\nbaz'")
+    assert.equal(quote('vs fast" && touch $HOME/Desktop/test.txt || echo "'), `$'vs fast\\" && touch $HOME/Desktop/test.txt || echo \\"'`)
   })
 })

--- a/target/cjs/util.cjs
+++ b/target/cjs/util.cjs
@@ -58,7 +58,8 @@ var assign = (target, ...extras) => Object.defineProperties(target, extras.reduc
 var quote = (arg) => {
   if (arg === "") return `$''`;
   if (/^[\w./:=@-]+$/.test(arg)) return arg;
-  return `$'` + arg.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\f/g, "\\f").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t").replace(/\v/g, "\\v").replace(/\0/g, "\\0") + `'`;
+  const safe = arg.replace(/\\/g, `\\\\`).replace(/'/g, `\\'`).replace(/"/g, `\\"`).replace(/\f/g, `\\f`).replace(/\n/g, `\\n`).replace(/\r/g, `\\r`).replace(/\t/g, `\\t`).replace(/\v/g, `\\v`).replace(/\0/g, `\\0`);
+  return `$'${safe}'`;
 };
 function quotePwsh(arg) {
   if (arg === "") return `''`;

--- a/target/esm/util.mjs
+++ b/target/esm/util.mjs
@@ -29,7 +29,8 @@ var assign = (target, ...extras) => Object.defineProperties(target, extras.reduc
 var quote = (arg) => {
   if (arg === "") return `$''`;
   if (/^[\w./:=@-]+$/.test(arg)) return arg;
-  return `$'` + arg.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/\f/g, "\\f").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t").replace(/\v/g, "\\v").replace(/\0/g, "\\0") + `'`;
+  const safe = arg.replace(/\\/g, `\\\\`).replace(/'/g, `\\'`).replace(/"/g, `\\"`).replace(/\f/g, `\\f`).replace(/\n/g, `\\n`).replace(/\r/g, `\\r`).replace(/\t/g, `\\t`).replace(/\v/g, `\\v`).replace(/\0/g, `\\0`);
+  return `$'${safe}'`;
 };
 function quotePwsh(arg) {
   if (arg === "") return `''`;


### PR DESCRIPTION
## Summary 

We are addressing the issue:  https://github.com/webpod/zurk/issues/37  

Added support for escaping the quote token to resolve the vulnerability associated with command injection.

## Demo

### Example input

`vs fast" && touch $HOME/Desktop/test.txt || echo "`

### Example output

`$'vs fast\" && touch $HOME/Desktop/test.txt || echo \"'`


## Screenshots

![CleanShot 2025-03-28 at 04 37 05](https://github.com/user-attachments/assets/2b7529be-9320-4def-b530-6fc1eba77abf)


#### See the relevant issue 

![CleanShot 2025-03-28 at 04 36 00@2x](https://github.com/user-attachments/assets/7f9f547e-26d2-4c00-90cf-52e2ddd67610)

